### PR TITLE
Fix LoganB Test

### DIFF
--- a/src/main/java/frc/robot/sensors/Camera.java
+++ b/src/main/java/frc/robot/sensors/Camera.java
@@ -120,6 +120,11 @@ public class Camera extends SensorLance
             return -1.00;
         }
     }
+
+    public double getTagId()
+    {
+        return LimelightHelpers.getFiducialID(cameraName);
+    }
     
 
     // *** OVERRIDEN METHODS ***
@@ -138,7 +143,7 @@ public class Camera extends SensorLance
 
             poseEntry.set(poseArray);
         }
-        LimelightHelpers.SetRobotOrientation(cameraName, yawEntry.get(), 0.0, 0.0, 0.0, 0.0, 0.0);
+        //LimelightHelpers.SetRobotOrientation(cameraName, yawEntry.get(), 0.0, 0.0, 0.0, 0.0, 0.0);
     }
 
     @Override

--- a/src/main/java/frc/robot/sensors/Camera.java
+++ b/src/main/java/frc/robot/sensors/Camera.java
@@ -60,8 +60,6 @@ public class Camera extends SensorLance
         poseEntry = ASTable.getDoubleArrayTopic(cameraName + " pose").getEntry(new double[3]);
         yawEntry = ASTable.getDoubleTopic("GyroYaw").getEntry(0.0);
 
-        poseEstimate = LimelightHelpers.getBotPoseEstimate_wpiBlue_MegaTag2(cameraName);
-
         System.out.println("  Constructor Finished: " + fullClassName + ">>" + cameraName);
     }
 
@@ -125,7 +123,31 @@ public class Camera extends SensorLance
     {
         return LimelightHelpers.getFiducialID(cameraName);
     }
-    
+
+    public double getTX()
+    {
+        return LimelightHelpers.getTX(cameraName);
+    }
+
+     public double getTY()
+    {
+        return LimelightHelpers.getTY(cameraName);
+    }   
+
+    public double getTA()
+    {
+        return LimelightHelpers.getTA(cameraName);
+    }
+
+    public boolean isValidTagInFrame()
+    {
+        return LimelightHelpers.getTV(cameraName);
+    }
+
+    public String getCameraName()
+    {
+        return cameraName;
+    }
 
     // *** OVERRIDEN METHODS ***
     // Put all methods that are Overridden here
@@ -143,7 +165,6 @@ public class Camera extends SensorLance
 
             poseEntry.set(poseArray);
         }
-        //LimelightHelpers.SetRobotOrientation(cameraName, yawEntry.get(), 0.0, 0.0, 0.0, 0.0, 0.0);
     }
 
     @Override

--- a/src/main/java/frc/robot/subsystems/PoseEstimator.java
+++ b/src/main/java/frc/robot/subsystems/PoseEstimator.java
@@ -191,9 +191,9 @@ public class PoseEstimator extends SubsystemLance
         stateStdDevs.set(1, 0, 0.1); // y in meters
         stateStdDevs.set(2, 0, 0.05); // heading in radians
 
-        visionStdDevs.set(0, 0, 0.5); // x in meters
-        visionStdDevs.set(1, 0, 0.5); // y in meters
-        visionStdDevs.set(2, 0, 0.55); // heading in radians
+        visionStdDevs.set(0, 0, 0.2); // x in meters
+        visionStdDevs.set(1, 0, 0.2); // y in meters
+        visionStdDevs.set(2, 0, 0.25); // heading in radians
     }
 
     private void fillMaps()
@@ -420,17 +420,19 @@ public class PoseEstimator extends SubsystemLance
             estimatedPose = poseEstimator.update(gyroRotation, swerveModulePositions);
         }
 
-        // TODO: Remove this when done testing, it is already done for any Camera.java object (check the camera class)j
-        LimelightHelpers.SetRobotOrientation("limelight-climb", estimatedPose.getRotation().getDegrees(), 0, 0, 0, 0, 0);
-
         for (Camera camera : cameraArray) 
         {
             if (camera != null)
             {
+                if(gyro != null)
+                {
+                    LimelightHelpers.SetRobotOrientation(camera.getCameraName(), gyro.getYaw(), 0.0, 0.0, 0.0, 0.0, 0.0);
+                }
+
                 if(camera.getTagCount() > 0)
                 {
                     Pose2d visionPose = camera.getPose();
-
+                    gyro.getYaw();
                     // variables for pose estimator logic
                     boolean rejectUpdate = false;
                     boolean reefTag = isReefTag(camera.getTagId());

--- a/src/main/java/frc/robot/subsystems/PoseEstimator.java
+++ b/src/main/java/frc/robot/subsystems/PoseEstimator.java
@@ -433,11 +433,9 @@ public class PoseEstimator extends SubsystemLance
 
                     // variables for pose estimator logic
                     boolean rejectUpdate = false;
-                    boolean reefTag = isReefTag(
-                            NetworkTableInstance.getDefault().getTable("limelight-climb").getEntry("tid").getDouble(0));
-                    double distToTag = getDistanceToReefTag(
-                            NetworkTableInstance.getDefault().getTable("limelight-climb").getEntry("tid").getDouble(0));
-                    double robotVelo = Math.sqrt(Math.pow(drivetrain.getState().Speeds.vxMetersPerSecond, 2) + Math.pow(drivetrain.getState().Speeds.vyMetersPerSecond, 2));
+                    boolean reefTag = isReefTag(camera.getTagId());
+                    double distToTag = getDistanceToReefTag(camera.getTagId());
+                    double robotVelo = Math.hypot(drivetrain.getState().Speeds.vxMetersPerSecond, drivetrain.getState().Speeds.vyMetersPerSecond);
                     double robotRotation = Math.toDegrees(drivetrain.getState().Speeds.omegaRadiansPerSecond);
 
                     if(visionPose != null)
@@ -481,6 +479,7 @@ public class PoseEstimator extends SubsystemLance
         //OUTPUTS
         if(drivetrain != null && gyro != null && poseEstimator != null)
         {
+            // grabs the newest estimated pose
             estimatedPose = poseEstimator.getEstimatedPosition();
 
             //puts pose onto AdvantageScope

--- a/src/main/java/frc/robot/subsystems/PoseEstimator.java
+++ b/src/main/java/frc/robot/subsystems/PoseEstimator.java
@@ -432,7 +432,6 @@ public class PoseEstimator extends SubsystemLance
                 if(camera.getTagCount() > 0)
                 {
                     Pose2d visionPose = camera.getPose();
-                    gyro.getYaw();
                     // variables for pose estimator logic
                     boolean rejectUpdate = false;
                     boolean reefTag = isReefTag(camera.getTagId());

--- a/src/main/java/frc/robot/tests/LoganBTest.java
+++ b/src/main/java/frc/robot/tests/LoganBTest.java
@@ -47,7 +47,7 @@ public class LoganBTest implements Test
     private final Claw claw;
     private final Elevator elevator;
     private final PoseEstimator poseEstimator;
-    private final Camera camera;
+    private final Camera climbSideLimelight;
     private final Joystick joystick = new Joystick(0);
     // private final ExampleSubsystem exampleSubsystem;
 
@@ -72,7 +72,7 @@ public class LoganBTest implements Test
         claw = robotContainer.getClaw();
         elevator = robotContainer.getElevator();
         poseEstimator = robotContainer.getPoseEstimator();
-        camera = robotContainer.getScoringSideCamera();
+        climbSideLimelight = robotContainer.getClimbSideCamera();
         System.out.println("  Constructor Finished: " + fullClassName);
     }
 
@@ -111,13 +111,7 @@ public class LoganBTest implements Test
         {
             // Retrieve the current estimated pose and the nearest scoring pose
             Pose2d currentPose = poseEstimator.getEstimatedPose();
-            int tagId = (int) NetworkTableInstance.getDefault()
-                    .getTable("limelight")
-                    .getEntry("tid")
-                    .getDouble(0);
-
-            System.out.println("X: " + currentPose.getX());
-            System.out.println("Y: " + currentPose.getY());
+            int tagId = (int) climbSideLimelight.getTagId();
 
             if(tagId != 0)
             {
@@ -140,7 +134,7 @@ public class LoganBTest implements Test
             }
             
         }
-        System.out.println(camera.getTagCount());
+        System.out.println(climbSideLimelight.getTagCount());
         // else if(joystick.getRawButton(2)) // B button
         // {
         //     // climb.climbDown();

--- a/src/main/java/frc/robot/tests/LoganBTest.java
+++ b/src/main/java/frc/robot/tests/LoganBTest.java
@@ -48,6 +48,7 @@ public class LoganBTest implements Test
     private final Elevator elevator;
     private final PoseEstimator poseEstimator;
     private final Camera climbSideLimelight;
+    private final Camera scoringSideLimelight;
     private final Joystick joystick = new Joystick(0);
     // private final ExampleSubsystem exampleSubsystem;
 
@@ -73,6 +74,7 @@ public class LoganBTest implements Test
         elevator = robotContainer.getElevator();
         poseEstimator = robotContainer.getPoseEstimator();
         climbSideLimelight = robotContainer.getClimbSideCamera();
+        scoringSideLimelight = robotContainer.getScoringSideCamera();
         System.out.println("  Constructor Finished: " + fullClassName);
     }
 
@@ -109,9 +111,20 @@ public class LoganBTest implements Test
         }
         else if(joystick.getRawButton(3))
         {
+            // TODO: SET THE CLIMB SIDE LL IN ROBOOTCONTAINER TO TRUE (OR SCORING SIDE IF
+            // WE ARE USING THE OTHER ONE. MAKE SURE YOU USE THE RIGHT CAMERA OBJECT!!!!
+            // TODO: DOUBLE CHECK THE LL IS NAMED CORRECTLY
+            // TODO: DOUBLE CHECK LL IS ON MOST RECENT 2024 FIRMWARE
+
             // Retrieve the current estimated pose and the nearest scoring pose
             Pose2d currentPose = poseEstimator.getEstimatedPose();
             int tagId = (int) climbSideLimelight.getTagId();
+            boolean validTagInFrame = climbSideLimelight.isValidTagInFrame();
+            int tagCount = climbSideLimelight.getTagCount();
+
+            // print out the primary tagId as well as the number of tags from the mt2 pose
+            System.out.printf("Primary Tag ID: %d | Valid Tag: %b | Tag Count: %d%n",
+                    tagId, validTagInFrame, tagCount);
 
             if(tagId != 0)
             {
@@ -134,7 +147,6 @@ public class LoganBTest implements Test
             }
             
         }
-        System.out.println(climbSideLimelight.getTagCount());
         // else if(joystick.getRawButton(2)) // B button
         // {
         //     // climb.climbDown();


### PR DESCRIPTION
added a getTagId method to the camera class (returns the main tagid in frame) 
Removed NTable calls to the LL in poseEstimator
Removed NTable calls to the LL in LBTests
Modified it to get the climb side camera (since that is the one logan is testing with, correct me if I am wrong)

For future reference, make sure that we are using the camera class to access the limelight. We had some random networktables calls floating around that were referencing "limelight" instead of "limelight-climb" or "limelight-scoring". If you need to be able to pull a new value off the limelight, add it in as a getter within the camera class.

**MAKE SURE TO SET THE CAMERA TO TRUE IN ROBOT CONTAINER BEFORE YOU TEST**